### PR TITLE
Integrate blazar events with ceilometer for gnocchi

### DIFF
--- a/base-helm-configs/blazar/blazar-helm-overrides.yaml
+++ b/base-helm-configs/blazar/blazar-helm-overrides.yaml
@@ -53,6 +53,10 @@ conf:
   blazar:
     DEFAULT:
       host_href: "http://blazar-api.openstack.svc.cluster.local:1234"
+    oslo_messaging_notifications:
+      driver: messagingv2
+      topics:
+        - notifications
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -160,22 +160,20 @@ conf:
           type: datetime
           fields: payload.audit_period_ending
     - event_type:
-        [
-          "volume.exists",
-          "volume.retype",
-          "volume.create.*",
-          "volume.delete.*",
-          "volume.resize.*",
-          "volume.attach.*",
-          "volume.detach.*",
-          "volume.update.*",
-          "snapshot.exists",
-          "snapshot.create.*",
-          "snapshot.delete.*",
-          "snapshot.update.*",
-          "volume.transfer.accept.end",
-          "snapshot.transfer.accept.end",
-        ]
+        - "volume.exists"
+        - "volume.retype"
+        - "volume.create.*"
+        - "volume.delete.*"
+        - "volume.resize.*"
+        - "volume.attach.*"
+        - "volume.detach.*"
+        - "volume.update.*"
+        - "snapshot.exists"
+        - "snapshot.create.*"
+        - "snapshot.delete.*"
+        - "snapshot.update.*"
+        - "volume.transfer.accept.end"
+        - "snapshot.transfer.accept.end"
       traits: &cinder_traits
         user_id:
           fields: payload.user_id
@@ -720,12 +718,14 @@ conf:
           fields: payload.nova_volume_id
     - event_type: trove.instance.create
       traits:
-        <<: *trove_base_traits
-        <<: *trove_common_traits
+        <<:
+          - *trove_base_traits
+          - *trove_common_traits
     - event_type: trove.instance.modify_volume
       traits:
-        <<: *trove_base_traits
-        <<: *trove_common_traits
+        <<:
+          - *trove_base_traits
+          - *trove_common_traits
         old_volume_size:
           type: int
           fields: payload.old_volume_size
@@ -734,8 +734,9 @@ conf:
           fields: payload.modify_at
     - event_type: trove.instance.modify_flavor
       traits:
-        <<: *trove_base_traits
-        <<: *trove_common_traits
+        <<:
+          - *trove_base_traits
+          - *trove_common_traits
         old_instance_size:
           type: int
           fields: payload.old_instance_size
@@ -744,8 +745,9 @@ conf:
           fields: payload.modify_at
     - event_type: trove.instance.delete
       traits:
-        <<: *trove_base_traits
-        <<: *trove_common_traits
+        <<:
+          - *trove_base_traits
+          - *trove_common_traits
         deleted_at:
           type: datetime
           fields: payload.deleted_at

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -195,18 +195,16 @@ conf:
         instance_id:
           fields: payload.volume_attachment[0].instance_uuid
     - event_type:
-        [
-          "volume.transfer.*",
-          "volume.exists",
-          "volume.retype",
-          "volume.create.*",
-          "volume.delete.*",
-          "volume.resize.*",
-          "volume.attach.*",
-          "volume.detach.*",
-          "volume.update.*",
-          "snapshot.transfer.accept.end",
-        ]
+        - "volume.transfer.*"
+        - "volume.exists"
+        - "volume.retype"
+        - "volume.create.*"
+        - "volume.delete.*"
+        - "volume.resize.*"
+        - "volume.attach.*"
+        - "volume.detach.*"
+        - "volume.update.*"
+        - "snapshot.transfer.accept.end"
       traits:
         <<: *cinder_traits
         resource_id:
@@ -842,18 +840,16 @@ conf:
           fields: payload.detail
         type:
           fields: payload.type
-  # Blazar events and metrics
+    # Blazar events and metrics
     - event_type:
-        [
-          "blazar.lease.create",
-          "blazar.lease.update",
-          "blazar.lease.delete",
-          "blazar.lease.start",
-          "blazar.lease.end",
-          "start_lease",
-          "end_lease",
-          "before_end_lease",
-        ]
+        - "blazar.lease.create"
+        - "blazar.lease.update"
+        - "blazar.lease.delete"
+        - "blazar.lease.start"
+        - "blazar.lease.end"
+        - "start_lease"
+        - "end_lease"
+        - "before_end_lease"
       traits: &blazar_lease_traits
         lease_id:
           fields:
@@ -884,14 +880,12 @@ conf:
           fields: payload.status
 
     - event_type:
-        [
-          "blazar.reservation.create",
-          "blazar.reservation.update",
-          "blazar.reservation.delete",
-          "blazar.reservation.instance.*",
-          "blazar.reservation.flavor.*",
-          "blazar.reservation.floatingip.*",
-        ]
+        - "blazar.reservation.create"
+        - "blazar.reservation.update"
+        - "blazar.reservation.delete"
+        - "blazar.reservation.instance.*"
+        - "blazar.reservation.flavor.*"
+        - "blazar.reservation.floatingip.*"
       traits: &blazar_reservation_traits
         reservation_id:
           fields:
@@ -1898,7 +1892,8 @@ conf:
         unit: "s"
         volume:
           fields:
-            [$.payload.audit_period_beginning, $.payload.audit_period_ending]
+            - $.payload.audit_period_beginning
+            - $.payload.audit_period_ending
           plugin: "timedelta"
         project_id: $.payload.tenant_id
         resource_id: $.payload.id
@@ -1915,7 +1910,8 @@ conf:
         unit: "s"
         volume:
           fields:
-            [$.payload.audit_period_beginning, $.payload.audit_period_ending]
+            - $.payload.audit_period_beginning
+            - $.payload.audit_period_ending
           plugin: "timedelta"
         project_id: $.payload.tenant_id
         resource_id: $.payload.instance_id

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -222,7 +222,8 @@ conf:
           fields: payload.volume_type
         replication_status:
           fields: payload.replication_status
-    - event_type: ["snapshot.transfer.accept.end"]
+    - event_type:
+        - "snapshot.transfer.accept.end"
       traits:
         <<: *cinder_traits
         resource_id:
@@ -230,7 +231,10 @@ conf:
         project_id:
           fields: payload.tenant_id
     - event_type:
-        ["share.create.*", "share.delete.*", "share.extend.*", "share.shrink.*"]
+        - "share.create.*"
+        - "share.delete.*"
+        - "share.extend.*"
+        - "share.shrink.*"
       traits: &share_traits
         share_id:
           fields: payload.share_id
@@ -263,26 +267,28 @@ conf:
         host:
           fields: payload.host
     - event_type:
-        [
-          "snapshot.exists",
-          "snapshot.create.*",
-          "snapshot.delete.*",
-          "snapshot.update.*",
-        ]
+        - "snapshot.exists"
+        - "snapshot.create.*"
+        - "snapshot.delete.*"
+        - "snapshot.update.*"
       traits:
         <<: *cinder_traits
         resource_id:
           fields: payload.snapshot_id
         volume_id:
           fields: payload.volume_id
-    - event_type: ["image_volume_cache.*"]
+    - event_type:
+        - "image_volume_cache.*"
       traits:
         image_id:
           fields: payload.image_id
         host:
           fields: payload.host
     - event_type:
-        ["image.create", "image.update", "image.upload", "image.delete"]
+        - "image.create"
+        - "image.update"
+        - "image.upload"
+        - "image.delete"
       traits: &glance_crud
         project_id:
           fields: payload.owner
@@ -323,7 +329,9 @@ conf:
         project_id:
           fields: payload.tenant_id
         user_id:
-          fields: ["ctxt.trustor_user_id", "ctxt.user_id"]
+          fields:
+            - "ctxt.trustor_user_id"
+            - "ctxt.user_id"
         resource_id:
           fields: payload.stack_identity
         name:
@@ -356,17 +364,15 @@ conf:
           type: datetime
           fields: payload.updated_at
     - event_type:
-        [
-          "identity.user.*",
-          "identity.project.*",
-          "identity.group.*",
-          "identity.role.*",
-          "identity.OS-TRUST:trust.*",
-          "identity.region.*",
-          "identity.service.*",
-          "identity.endpoint.*",
-          "identity.policy.*",
-        ]
+        - "identity.user.*"
+        - "identity.project.*"
+        - "identity.group.*"
+        - "identity.role.*"
+        - "identity.OS-TRUST:trust.*"
+        - "identity.region.*"
+        - "identity.service.*"
+        - "identity.endpoint.*"
+        - "identity.policy.*"
       traits: &identity_crud
         resource_id:
           fields: payload.resource_info
@@ -459,20 +465,18 @@ conf:
         observer_id:
           fields: payload.observer.id
     - event_type:
-        [
-          "network.*",
-          "subnet.*",
-          "port.*",
-          "router.*",
-          "floatingip.*",
-          "firewall.*",
-          "firewall_policy.*",
-          "firewall_rule.*",
-          "vpnservice.*",
-          "ipsecpolicy.*",
-          "ikepolicy.*",
-          "ipsec_site_connection.*",
-        ]
+        - "network.*"
+        - "subnet.*"
+        - "port.*"
+        - "router.*"
+        - "floatingip.*"
+        - "firewall.*"
+        - "firewall_policy.*"
+        - "firewall_rule.*"
+        - "vpnservice.*"
+        - "ipsecpolicy.*"
+        - "ikepolicy.*"
+        - "ipsec_site_connection.*"
       traits: &network_traits
         user_id:
           fields: ctxt.user_id
@@ -484,21 +488,27 @@ conf:
         name:
           fields: payload.network.name
         resource_id:
-          fields: ["payload.network.id", "payload.id"]
+          fields:
+            - "payload.network.id"
+            - "payload.id"
     - event_type: subnet.*
       traits:
         <<: *network_traits
         name:
           fields: payload.subnet.name
         resource_id:
-          fields: ["payload.subnet.id", "payload.id"]
+          fields:
+            - "payload.subnet.id"
+            - "payload.id"
     - event_type: port.*
       traits:
         <<: *network_traits
         name:
           fields: payload.port.name
         resource_id:
-          fields: ["payload.port.id", "payload.id"]
+          fields:
+            - "payload.port.id"
+            - "payload.id"
     - event_type: router.*
       traits:
         <<: *network_traits
@@ -523,47 +533,61 @@ conf:
         name:
           fields: payload.firewall.name
         resource_id:
-          fields: ["payload.firewall.id", "payload.id"]
+          fields:
+            - "payload.firewall.id"
+            - "payload.id"
     - event_type: firewall_policy.*
       traits:
         <<: *network_traits
         name:
           fields: payload.firewall_policy.name
         resource_id:
-          fields: ["payload.firewall_policy.id", "payload.id"]
+          fields:
+            - "payload.firewall_policy.id"
+            - "payload.id"
     - event_type: firewall_rule.*
       traits:
         <<: *network_traits
         name:
           fields: payload.firewall_rule.name
         resource_id:
-          fields: ["payload.firewall_rule.id", "payload.id"]
+          fields:
+            - "payload.firewall_rule.id"
+            - "payload.id"
     - event_type: vpnservice.*
       traits:
         <<: *network_traits
         name:
           fields: payload.vpnservice.name
         resource_id:
-          fields: ["payload.vpnservice.id", "payload.id"]
+          fields:
+            - "payload.vpnservice.id"
+            - "payload.id"
     - event_type: ipsecpolicy.*
       traits:
         <<: *network_traits
         name:
           fields: payload.ipsecpolicy.name
         resource_id:
-          fields: ["payload.ipsecpolicy.id", "payload.id"]
+          fields:
+            - "payload.ipsecpolicy.id"
+            - "payload.id"
     - event_type: ikepolicy.*
       traits:
         <<: *network_traits
         name:
           fields: payload.ikepolicy.name
         resource_id:
-          fields: ["payload.ikepolicy.id", "payload.id"]
+          fields:
+            - "payload.ikepolicy.id"
+            - "payload.id"
     - event_type: ipsec_site_connection.*
       traits:
         <<: *network_traits
         resource_id:
-          fields: ["payload.ipsec_site_connection.id", "payload.id"]
+          fields:
+            - "payload.ipsec_site_connection.id"
+            - "payload.id"
     - event_type: "*http.*"
       traits: &http_audit
         project_id:
@@ -607,7 +631,9 @@ conf:
         reason_code:
           fields: payload.reason.reasonCode
     - event_type:
-        ["dns.domain.create", "dns.domain.update", "dns.domain.delete"]
+        - "dns.domain.create"
+        - "dns.domain.update"
+        - "dns.domain.delete"
       traits: &dns_domain_traits
         status:
           fields: payload.status
@@ -675,12 +701,10 @@ conf:
         region:
           fields: payload.region
     - event_type:
-        [
-          "trove.instance.create",
-          "trove.instance.modify_volume",
-          "trove.instance.modify_flavor",
-          "trove.instance.delete",
-        ]
+        - "trove.instance.create"
+        - "trove.instance.modify_volume"
+        - "trove.instance.modify_flavor"
+        - "trove.instance.delete"
       traits: &trove_common_traits
         name:
           fields: payload.name
@@ -696,10 +720,12 @@ conf:
           fields: payload.nova_volume_id
     - event_type: trove.instance.create
       traits:
-        <<: [*trove_base_traits, *trove_common_traits]
+        <<: *trove_base_traits
+        <<: *trove_common_traits
     - event_type: trove.instance.modify_volume
       traits:
-        <<: [*trove_base_traits, *trove_common_traits]
+        <<: *trove_base_traits
+        <<: *trove_common_traits
         old_volume_size:
           type: int
           fields: payload.old_volume_size
@@ -708,7 +734,8 @@ conf:
           fields: payload.modify_at
     - event_type: trove.instance.modify_flavor
       traits:
-        <<: [*trove_base_traits, *trove_common_traits]
+        <<: *trove_base_traits
+        <<: *trove_common_traits
         old_instance_size:
           type: int
           fields: payload.old_instance_size
@@ -717,7 +744,8 @@ conf:
           fields: payload.modify_at
     - event_type: trove.instance.delete
       traits:
-        <<: [*trove_base_traits, *trove_common_traits]
+        <<: *trove_base_traits
+        <<: *trove_common_traits
         deleted_at:
           type: datetime
           fields: payload.deleted_at
@@ -826,13 +854,19 @@ conf:
         ]
       traits: &blazar_lease_traits
         lease_id:
-          fields: [payload.lease_id, payload.id]
+          fields:
+            - payload.lease_id
+            - payload.id
         resource_id:
-          fields: [payload.lease_id, payload.id]
+          fields:
+            - payload.lease_id
+            - payload.id
         name:
           fields: payload.name
         project_id:
-          fields: [payload.project_id, payload.tenant_id]
+          fields:
+            - payload.project_id
+            - payload.tenant_id
         user_id:
           fields: payload.user_id
         start_date:
@@ -858,11 +892,17 @@ conf:
         ]
       traits: &blazar_reservation_traits
         reservation_id:
-          fields: [payload.reservation_id, payload.id]
+          fields:
+            - payload.reservation_id
+            - payload.id
         lease_id:
-          fields: [payload.lease_id, payload.lease.id]
+          fields:
+            - payload.lease_id
+            - payload.lease.id
         resource_id:
-          fields: [payload.lease_id, payload.lease.id]
+          fields:
+            - payload.lease_id
+            - payload.lease.id
         resource_type:
           fields: payload.resource_type
         amount:
@@ -1621,7 +1661,10 @@ conf:
         user_id: $.payload.user_id
         project_id: $.payload.project_id
         resource_id: $.payload.resource_id
-        lookup: ["name", "unit", "volume"]
+        lookup:
+          - "name"
+          - "unit"
+          - "volume"
 
       # Swift
       - name: $.payload.measurements.[*].metric.[*].name
@@ -1632,7 +1675,10 @@ conf:
         resource_id: $.payload.target.id
         user_id: $.payload.initiator.id
         project_id: $.payload.initiator.project_id
-        lookup: ["name", "unit", "volume"]
+        lookup:
+          - "name"
+          - "unit"
+          - "volume"
 
       - name: "memory"
         event_type: &instance_events compute.instance.(?!create.start|update).*
@@ -1670,7 +1716,9 @@ conf:
         type: "gauge"
         unit: "sec"
         volume:
-          fields: [$.payload.created_at, $.payload.launched_at]
+          fields:
+            - $.payload.created_at
+            - $.payload.launched_at
           plugin: "timedelta"
         project_id: $.payload.tenant_id
         resource_id: $.payload.instance_id

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -60,6 +60,7 @@ conf:
           - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/neutron
           - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/heat
           - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/swift
+          - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/blazar
     oslo_messaging_notifications:
       driver: messagingv2
       topics:
@@ -811,6 +812,84 @@ conf:
           fields: payload.detail
         type:
           fields: payload.type
+  # Blazar events and metrics
+  - event_type:
+      [
+        "blazar.lease.create",
+        "blazar.lease.update",
+        "blazar.lease.delete",
+        "blazar.lease.start",
+        "blazar.lease.end",
+        "start_lease",
+        "end_lease",
+        "before_end_lease",
+      ]
+    traits: &blazar_lease_traits
+      lease_id:
+        fields: [payload.lease_id, payload.id]
+      resource_id:
+        fields: [payload.lease_id, payload.id]
+      name:
+        fields: payload.name
+      project_id:
+        fields: [payload.project_id, payload.tenant_id]
+      user_id:
+        fields: payload.user_id
+      start_date:
+        type: datetime
+        fields: payload.start_date
+      end_date:
+        type: datetime
+        fields: payload.end_date
+      event_time:
+        type: datetime
+        fields: payload.time
+      status:
+        fields: payload.status
+
+  - event_type:
+      [
+        "blazar.reservation.create",
+        "blazar.reservation.update",
+        "blazar.reservation.delete",
+        "blazar.reservation.instance.*",
+        "blazar.reservation.flavor.*",
+        "blazar.reservation.floatingip.*",
+      ]
+    traits: &blazar_reservation_traits
+      reservation_id:
+        fields: [payload.reservation_id, payload.id]
+      lease_id:
+        fields: [payload.lease_id, payload.lease.id]
+      resource_id:
+        fields: [payload.lease_id, payload.lease.id]
+      resource_type:
+        fields: payload.resource_type
+      amount:
+        type: int
+        fields: payload.amount
+      vcpus:
+        type: int
+        fields: payload.vcpus
+      memory_mb:
+        type: int
+        fields: payload.memory_mb
+      disk_gb:
+        type: int
+        fields: payload.disk_gb
+      min:
+        type: int
+        fields: payload.min
+      max:
+        type: int
+        fields: payload.max
+      flavor_id:
+        fields: payload.flavor_id
+      network_id:
+        fields: payload.network_id
+      required_floatingips:
+        fields: payload.required_floatingips
+
   gnocchi_resources:
     archive_policy_default: ceilometer-low
     archive_policies:
@@ -856,6 +935,38 @@ conf:
             timespan: 365 days
 
     resources:
+      - resource_type: blazar_lease
+        metrics:
+          blazar.lease.create:
+          blazar.lease.start:
+          blazar.lease.before_end:
+          blazar.lease.end:
+          blazar.reservation.instance.amount:
+          blazar.reservation.instance.vcpus:
+          blazar.reservation.instance.memory_mb:
+          blazar.reservation.instance.disk_gb:
+          blazar.reservation.host.min:
+          blazar.reservation.host.max:
+          blazar.reservation.flavor.amount:
+          blazar.reservation.fip.amount:
+        event_create:
+          - blazar.lease.create
+          - blazar.lease.start
+          - start_lease
+        event_update:
+          - blazar.lease.update
+          - blazar.lease.end
+          - end_lease
+          - before_end_lease
+        event_delete:
+          - blazar.lease.delete
+        event_attributes:
+          id: lease_id
+          name: name
+          project_id: project_id
+          user_id: user_id
+          start_date: start_date
+          end_date: end_date
       - resource_type: identity
         metrics:
           identity.authenticate.success:
@@ -1216,6 +1327,128 @@ conf:
 
   meters:
     metric:
+      # Blazar lease lifecycle and reservation metrics
+      - name: "blazar.lease.create"
+        event_type:
+          - "blazar.lease.create"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.lease.start"
+        event_type:
+          - "blazar.lease.start"
+          - "start_lease"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.lease.before_end"
+        event_type:
+          - "before_end_lease"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.lease.end"
+        event_type:
+          - "blazar.lease.end"
+          - "end_lease"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.instance.amount"
+        event_type:
+          - "blazar.reservation.instance.*"
+        type: "gauge"
+        unit: "instances"
+        volume: $.payload.amount
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.instance.vcpus"
+        event_type:
+          - "blazar.reservation.instance.*"
+        type: "gauge"
+        unit: "vcpu"
+        volume: $.payload.vcpus
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.instance.memory_mb"
+        event_type:
+          - "blazar.reservation.instance.*"
+        type: "gauge"
+        unit: "MB"
+        volume: $.payload.memory_mb
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.instance.disk_gb"
+        event_type:
+          - "blazar.reservation.instance.*"
+        type: "gauge"
+        unit: "GB"
+        volume: $.payload.disk_gb
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.host.min"
+        event_type:
+          - "blazar.reservation.*"
+        type: "gauge"
+        unit: "hosts"
+        volume: $.payload.min
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.host.max"
+        event_type:
+          - "blazar.reservation.*"
+        type: "gauge"
+        unit: "hosts"
+        volume: $.payload.max
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.flavor.amount"
+        event_type:
+          - "blazar.reservation.flavor.*"
+        type: "gauge"
+        unit: "instances"
+        volume: $.payload.amount
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+
+      - name: "blazar.reservation.fip.amount"
+        event_type:
+          - "blazar.reservation.floatingip.*"
+        type: "gauge"
+        unit: "ips"
+        volume: $.payload.amount
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
       # Image
       - name: "image.size"
         event_type:

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -813,82 +813,82 @@ conf:
         type:
           fields: payload.type
   # Blazar events and metrics
-  - event_type:
-      [
-        "blazar.lease.create",
-        "blazar.lease.update",
-        "blazar.lease.delete",
-        "blazar.lease.start",
-        "blazar.lease.end",
-        "start_lease",
-        "end_lease",
-        "before_end_lease",
-      ]
-    traits: &blazar_lease_traits
-      lease_id:
-        fields: [payload.lease_id, payload.id]
-      resource_id:
-        fields: [payload.lease_id, payload.id]
-      name:
-        fields: payload.name
-      project_id:
-        fields: [payload.project_id, payload.tenant_id]
-      user_id:
-        fields: payload.user_id
-      start_date:
-        type: datetime
-        fields: payload.start_date
-      end_date:
-        type: datetime
-        fields: payload.end_date
-      event_time:
-        type: datetime
-        fields: payload.time
-      status:
-        fields: payload.status
+    - event_type:
+        [
+          "blazar.lease.create",
+          "blazar.lease.update",
+          "blazar.lease.delete",
+          "blazar.lease.start",
+          "blazar.lease.end",
+          "start_lease",
+          "end_lease",
+          "before_end_lease",
+        ]
+      traits: &blazar_lease_traits
+        lease_id:
+          fields: [payload.lease_id, payload.id]
+        resource_id:
+          fields: [payload.lease_id, payload.id]
+        name:
+          fields: payload.name
+        project_id:
+          fields: [payload.project_id, payload.tenant_id]
+        user_id:
+          fields: payload.user_id
+        start_date:
+          type: datetime
+          fields: payload.start_date
+        end_date:
+          type: datetime
+          fields: payload.end_date
+        event_time:
+          type: datetime
+          fields: payload.time
+        status:
+          fields: payload.status
 
-  - event_type:
-      [
-        "blazar.reservation.create",
-        "blazar.reservation.update",
-        "blazar.reservation.delete",
-        "blazar.reservation.instance.*",
-        "blazar.reservation.flavor.*",
-        "blazar.reservation.floatingip.*",
-      ]
-    traits: &blazar_reservation_traits
-      reservation_id:
-        fields: [payload.reservation_id, payload.id]
-      lease_id:
-        fields: [payload.lease_id, payload.lease.id]
-      resource_id:
-        fields: [payload.lease_id, payload.lease.id]
-      resource_type:
-        fields: payload.resource_type
-      amount:
-        type: int
-        fields: payload.amount
-      vcpus:
-        type: int
-        fields: payload.vcpus
-      memory_mb:
-        type: int
-        fields: payload.memory_mb
-      disk_gb:
-        type: int
-        fields: payload.disk_gb
-      min:
-        type: int
-        fields: payload.min
-      max:
-        type: int
-        fields: payload.max
-      flavor_id:
-        fields: payload.flavor_id
-      network_id:
-        fields: payload.network_id
-      required_floatingips:
-        fields: payload.required_floatingips
+    - event_type:
+        [
+          "blazar.reservation.create",
+          "blazar.reservation.update",
+          "blazar.reservation.delete",
+          "blazar.reservation.instance.*",
+          "blazar.reservation.flavor.*",
+          "blazar.reservation.floatingip.*",
+        ]
+      traits: &blazar_reservation_traits
+        reservation_id:
+          fields: [payload.reservation_id, payload.id]
+        lease_id:
+          fields: [payload.lease_id, payload.lease.id]
+        resource_id:
+          fields: [payload.lease_id, payload.lease.id]
+        resource_type:
+          fields: payload.resource_type
+        amount:
+          type: int
+          fields: payload.amount
+        vcpus:
+          type: int
+          fields: payload.vcpus
+        memory_mb:
+          type: int
+          fields: payload.memory_mb
+        disk_gb:
+          type: int
+          fields: payload.disk_gb
+        min:
+          type: int
+          fields: payload.min
+        max:
+          type: int
+          fields: payload.max
+        flavor_id:
+          fields: payload.flavor_id
+        network_id:
+          fields: payload.network_id
+        required_floatingips:
+          fields: payload.required_floatingips
 
   gnocchi_resources:
     archive_policy_default: ceilometer-low

--- a/bin/install-ceilometer.sh
+++ b/bin/install-ceilometer.sh
@@ -51,7 +51,8 @@ rabbit://neutron:$(kubectl --namespace openstack get secret neutron-rabbitmq-pas
 rabbit://cinder:$(kubectl --namespace openstack get secret cinder-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/cinder,\
 rabbit://heat:$(kubectl --namespace openstack get secret heat-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/heat,\
 rabbit://octavia:$(kubectl --namespace openstack get secret octavia-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/octavia,\
-rabbit://magnum:$(kubectl --namespace openstack get secret magnum-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/magnum}\""
+rabbit://magnum:$(kubectl --namespace openstack get secret magnum-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/magnum,\\
+rabbit://blazar:$(kubectl --namespace openstack get secret blazar-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/blazar}\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
 HELM_CMD+=" --post-renderer-args ceilometer/overlay"


### PR DESCRIPTION
Enable Blazar notifications and configure Ceilometer to collect Blazar lease and reservation metrics into Gnocchi. This integrates Blazar's compute host, instance, flavor, and floating IP reservation events for monitoring.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a56ba29-193c-45ac-a921-278bb4dbbb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a56ba29-193c-45ac-a921-278bb4dbbb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

