### PR TITLE
Fix blazar resource metric retrieval

### DIFF
--- a/base-helm-configs/blazar/blazar-helm-overrides.yaml
+++ b/base-helm-configs/blazar/blazar-helm-overrides.yaml
@@ -53,6 +53,10 @@ conf:
   blazar:
     DEFAULT:
       host_href: "http://blazar-api.openstack.svc.cluster.local:1234"
+    oslo_messaging_notifications:
+      driver: messagingv2
+      topics:
+        - notifications
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -60,6 +60,7 @@ conf:
           - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/neutron
           - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/heat
           - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/swift
+          - rabbit://rabbitmq:password@rabbitmq.openstack.svc.cluster.local:5672/blazar
     oslo_messaging_notifications:
       driver: messagingv2
       topics:
@@ -159,6 +160,28 @@ conf:
           type: datetime
           fields: payload.audit_period_ending
     - event_type:
+        [
+          "blazar.lease.create.*",
+          "blazar.lease.update.*",
+          "blazar.lease.delete.*",
+        ]
+      traits: &blazar_lease_traits
+        resource_id:
+          fields: payload.lease_id
+        lease_name:
+          fields: payload.name
+        project_id:
+          fields: payload.project_id
+        user_id:
+          fields: payload.user_id
+        start_date:
+          type: datetime
+          fields: payload.start_date
+        end_date:
+          type: datetime
+          fields: payload.end_date
+        status:
+          fields: payload.status
         [
           "volume.exists",
           "volume.retype",
@@ -856,6 +879,25 @@ conf:
             timespan: 365 days
 
     resources:
+      - resource_type: blazar_lease
+        metrics:
+          blazar.lease.create:
+          blazar.lease.update:
+          blazar.lease.delete:
+        attributes:
+          project_id: resource_metadata.project_id
+          user_id: resource_metadata.user_id
+          name: resource_metadata.lease_name
+          start_date: resource_metadata.start_date
+          end_date: resource_metadata.end_date
+        event_create:
+          - blazar.lease.create.end
+        event_delete:
+          - blazar.lease.delete.end
+        event_update:
+          - blazar.lease.update.end
+        event_attributes:
+          id: resource_id
       - resource_type: identity
         metrics:
           identity.authenticate.success:
@@ -1663,6 +1705,49 @@ conf:
           status: $.payload.status
           availability_zone: $.payload.availability_zone
           protocol: $.payload.proto
+
+      # Blazar
+      - name: "blazar.lease.create"
+        event_type: "blazar.lease.create.end"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+        metadata:
+          lease_name: $.payload.name
+          start_date: $.payload.start_date
+          end_date: $.payload.end_date
+          status: $.payload.status
+
+      - name: "blazar.lease.update"
+        event_type: "blazar.lease.update.end"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+        metadata:
+          lease_name: $.payload.name
+          start_date: $.payload.start_date
+          end_date: $.payload.end_date
+          status: $.payload.status
+
+      - name: "blazar.lease.delete"
+        event_type: "blazar.lease.delete.end"
+        type: "delta"
+        unit: "lease"
+        volume: 1
+        project_id: $.payload.project_id
+        user_id: $.payload.user_id
+        resource_id: $.payload.lease_id
+        metadata:
+          lease_name: $.payload.name
+          start_date: $.payload.start_date
+          end_date: $.payload.end_date
+          status: $.payload.status
 
   polling:
     sources:

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -161,6 +161,9 @@ conf:
           fields: payload.audit_period_ending
     - event_type:
         [
+          "reservation.lease.create.*",
+          "reservation.lease.update.*",
+          "reservation.lease.delete.*",
           "blazar.lease.create.*",
           "blazar.lease.update.*",
           "blazar.lease.delete.*",
@@ -881,6 +884,9 @@ conf:
     resources:
       - resource_type: blazar_lease
         metrics:
+          reservation.lease.create:
+          reservation.lease.update:
+          reservation.lease.delete:
           blazar.lease.create:
           blazar.lease.update:
           blazar.lease.delete:
@@ -1708,7 +1714,7 @@ conf:
 
       # Blazar
       - name: "blazar.lease.create"
-        event_type: "blazar.lease.create.end"
+        event_type: ["reservation.lease.create.*", "blazar.lease.create.*"]
         type: "delta"
         unit: "lease"
         volume: 1
@@ -1722,7 +1728,7 @@ conf:
           status: $.payload.status
 
       - name: "blazar.lease.update"
-        event_type: "blazar.lease.update.end"
+        event_type: ["reservation.lease.update.*", "blazar.lease.update.*"]
         type: "delta"
         unit: "lease"
         volume: 1
@@ -1736,7 +1742,7 @@ conf:
           status: $.payload.status
 
       - name: "blazar.lease.delete"
-        event_type: "blazar.lease.delete.end"
+        event_type: ["reservation.lease.delete.*", "blazar.lease.delete.*"]
         type: "delta"
         unit: "lease"
         volume: 1


### PR DESCRIPTION
Enable Blazar notifications and Ceilometer integration to define the `blazar_lease` Gnocchi resource type and associated metrics.

This change resolves the "Resource type blazar_lease does not exist (HTTP 404)" error by properly configuring Blazar to emit notifications, subscribing Ceilometer to these notifications, and defining the necessary Gnocchi resource type mapping and meters for Blazar lease events.

---
<a href="https://cursor.com/background-agent?bcId=bc-0944fcca-5f39-417c-a5b1-64f75782e7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0944fcca-5f39-417c-a5b1-64f75782e7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

